### PR TITLE
Update SuperTux to 0.5.1

### DIFF
--- a/games/supertux/build.sh
+++ b/games/supertux/build.sh
@@ -8,7 +8,7 @@ source ${lib_path}util.sh
 source ${lib_path}upload_handler.sh
 
 root_dir=$(pwd)
-version=0.5.0
+version=0.5.1
 arch=$(uname -m)
 source_dir=${root_dir}/supertux-${version}
 build_dir=${root_dir}/supertux-build


### PR DESCRIPTION
https://supertuxproject.org/news/2016/11/05/0.5.1

It compiled, but at the end, I'm getting...

```
[100%] Built target supertux2
cp: cannot stat 'external/tinygettext/libtinygettext.so': No such file or directory
```