### PR TITLE
Stop clone function in lib/util.sh from changing directory

### DIFF
--- a/games/xoreos/build.sh
+++ b/games/xoreos/build.sh
@@ -12,6 +12,7 @@ build_dir="${root_dir}/xoreos-build"
 install_deps "libfaad-dev libxvidcore-dev"
 
 clone https://github.com/xoreos/xoreos.git $source_dir
+cd "${source_dir}"
 
 mkdir  -p $build_dir
 cd $build_dir

--- a/games/yamagi/build.sh
+++ b/games/yamagi/build.sh
@@ -26,6 +26,7 @@ done
 
 source_dir=${root_dir}/${package_name}-${game}-src
 clone https://github.com/yquake2/${game}.git ${source_dir}
+cd "${source_dir}"
 if [ "$game" = "yquake2" ]; then
     git checkout ${tag}
 fi

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -14,10 +14,10 @@ function clone {
         cd ${source_dir}
         git checkout master
         git pull
+        cd ..
     else
         echo "Cloning sources"
         git clone ${recurse} ${repo_url} ${source_dir}
-        cd $source_dir
     fi
     if [ "$tag" ]; then
         git checkout ${tag}

--- a/runners/citra/build.sh
+++ b/runners/citra/build.sh
@@ -23,6 +23,7 @@ InstallDependencies() {
 
 GetSources() {
     clone https://github.com/citra-emu/citra ${source_dir} recurse
+    cd "${source_dir}"
 }
 
 Build() {

--- a/runners/citra/build.sh
+++ b/runners/citra/build.sh
@@ -23,10 +23,10 @@ InstallDependencies() {
 
 GetSources() {
     clone https://github.com/citra-emu/citra ${source_dir} recurse
-    cd "${source_dir}"
 }
 
 Build() {
+    cd "${source_dir}"
     mkdir -p $build_dir
     cd $build_dir
     cmake $source_dir \

--- a/runners/dolphin/build.sh
+++ b/runners/dolphin/build.sh
@@ -28,11 +28,11 @@ InstallBuildDependencies() {
 
 GetSources() {
     clone $repo_url $source_dir
-    cd "${source_dir}"
 }
 
 
 BuildProject() {
+    cd "${source_dir}"
     mkdir -p ${build_dir}
     cd ${build_dir}
     cmake -DLINUX_LOCAL_DEV=1 ${source_dir}

--- a/runners/dolphin/build.sh
+++ b/runners/dolphin/build.sh
@@ -28,6 +28,7 @@ InstallBuildDependencies() {
 
 GetSources() {
     clone $repo_url $source_dir
+    cd "${source_dir}"
 }
 
 

--- a/runners/fs-uae/build.sh
+++ b/runners/fs-uae/build.sh
@@ -17,7 +17,7 @@ deps="libglew-dev libmpeg2-4-dev libsdl2-dev zip"
 
 install_deps $deps
 clone $repo_url $source_dir
-
+cd "${source_dir}"
 mkdir -p ${build_dir}
 
 cd $source_dir

--- a/runners/libretro/build.sh
+++ b/runners/libretro/build.sh
@@ -27,6 +27,7 @@ done
 core="$1"
 
 clone git://github.com/libretro/libretro-super.git $source_dir
+cd "${source_dir}"
 
 mkdir -p ${bin_dir}
 

--- a/runners/residualvm/build.sh
+++ b/runners/residualvm/build.sh
@@ -17,6 +17,7 @@ version="0.3.0git"
 
 repo_url="https://github.com/residualvm/residualvm.git"
 clone $repo_url $source_dir
+cd "${source_dir}"
 
 deps="libsdl1.2-dev"
 install_deps $deps

--- a/runners/yabause/build.sh
+++ b/runners/yabause/build.sh
@@ -28,10 +28,10 @@ DownloadStable() {
 
 DownloadGit() {
     clone https://github.com/Yabause/yabause.git ${source_dir}
-    cd "${source_dir}"
 }
 
 BuildProject() {
+    cd "${source_dir}"
     mkdir -p $build_dir
     cd $build_dir
     cmake ${source_dir}/yabause -DCMAKE_BUILD_TYPE=Release

--- a/runners/yabause/build.sh
+++ b/runners/yabause/build.sh
@@ -28,6 +28,7 @@ DownloadStable() {
 
 DownloadGit() {
     clone https://github.com/Yabause/yabause.git ${source_dir}
+    cd "${source_dir}"
 }
 
 BuildProject() {

--- a/tools/unshield/build.sh
+++ b/tools/unshield/build.sh
@@ -15,10 +15,10 @@ bin_dir="${root_dir}/${pkg_name}"
 
 GetSources() {
     clone https://github.com/twogood/unshield.git $source_dir
-    cd "${source_dir}"
 }
 
 BuildProject() {
+    cd "${source_dir}"
     mkdir -p $build_dir
     cd $build_dir
     cmake $source_dir

--- a/tools/unshield/build.sh
+++ b/tools/unshield/build.sh
@@ -15,6 +15,7 @@ bin_dir="${root_dir}/${pkg_name}"
 
 GetSources() {
     clone https://github.com/twogood/unshield.git $source_dir
+    cd "${source_dir}"
 }
 
 BuildProject() {


### PR DESCRIPTION
This is seemingly unintentional behavior given there are about 2 build scripts in a total of 79 that expect the clone function to do this.

Still, just to be cautious, and since I don't have my own buildbot I changed 9 scripts total that didn't immediately run

cd ${source_dir}

after git cloning just to be 100% sure this won't break anything but I expect most of these changes are unnecessary, especially on the newer packages.