### PR TITLE
libretro: Update to retroarch 1.7.5

### DIFF
--- a/runners/libretro/.gitignore
+++ b/runners/libretro/.gitignore
@@ -1,1 +1,3 @@
-libretro-super
+/libretro-super
+/retroarch
+/retroarch-*

--- a/runners/libretro/build.sh
+++ b/runners/libretro/build.sh
@@ -61,6 +61,9 @@ BuildRetroarch() {
         ${bin_dir}/assets/wallpapers \
         ${bin_dir}/assets/xmb/retroactive
 
+    # autoconfig
+    cp -a media/autoconfig ${bin_dir}
+
     # Info files
     cp -a ../dist/info ${bin_dir}
 

--- a/runners/libretro/build.sh
+++ b/runners/libretro/build.sh
@@ -8,7 +8,7 @@ source ${lib_path}util.sh
 source ${lib_path}upload_handler.sh
 
 runner_name=$(get_runner)
-retroarch_version="1.7.3"
+retroarch_version="1.7.5"
 root_dir="$(pwd)"
 source_dir="${root_dir}/libretro-super"
 bin_dir="${root_dir}/retroarch"
@@ -50,8 +50,16 @@ BuildRetroarch() {
     cp tools/cg2glsl.py ${bin_dir}/retroarch-cg2glsl
 
     # Assets
+    # TODO: Restore files that pushed the package size to be too big
+    # - assets/wallpapers
+    # - assets/xmb/retroactive
     cp -a media/assets ${bin_dir}
-    rm -rf ${bin_dir}/assets/.git
+    rm -rf ${bin_dir}/assets/.git \
+        ${bin_dir}/assets/src \
+        ${bin_dir}/assets/switch \
+        ${bin_dir}/assets/nxrgui \
+        ${bin_dir}/assets/wallpapers \
+        ${bin_dir}/assets/xmb/retroactive
 
     # Info files
     cp -a ../dist/info ${bin_dir}


### PR DESCRIPTION
Updated on buildbot:
https://lutris.net/files/runners/

Had to remove some of the asset files to ensure the package doesn't go beyond the max filesize. But it's up now!