### PR TITLE
Bring back rebased dotnet471 patch

### DIFF
--- a/tools/winetricks/build.sh
+++ b/tools/winetricks/build.sh
@@ -26,6 +26,9 @@ BuildProject() {
     # Fix language bug on unattended dotnet462 install
     sed -i 's/WINEDLLOVERRIDES=fusion=b "$WINE" "$file_package" ${W_OPT_UNATTENDED:+$unattended_args}/WINEDLLOVERRIDES=fusion=b "$WINE" "$file_package" \/sfxlang:1027 ${W_OPT_UNATTENDED:+$unattended_args}/g' src/winetricks
 
+    # dotnet471 support, 64-bit mostly working	
+    patch -Np1 < ../'patches/dotnet471.patch'
+
     mkdir -p "${bin_dir}"
     cp "${source_dir}/src/winetricks" "${bin_dir}"
 }

--- a/tools/winetricks/patches/dotnet471.patch
+++ b/tools/winetricks/patches/dotnet471.patch
@@ -1,0 +1,126 @@
+From 274407fb08fef2db8b43920834c9270667c62ab0 Mon Sep 17 00:00:00 2001
+From: Tk-Glitch <ti3nou@gmail.com>
+Date: Thu, 26 Jul 2018 13:32:01 +0200
+Subject: Add dotnet471 installer and workarounds, with working 64-bit install (for the most part)
+
+
+diff --git a/files/verbs/all.txt b/files/verbs/all.txt
+index c5b0089..41b1f96 100644
+--- a/files/verbs/all.txt
++++ b/files/verbs/all.txt
+@@ -142,6 +142,7 @@ dotnet452                MS .NET 4.5.2 (Microsoft, 2012) [downloadable]
+ dotnet461                MS .NET 4.6.1 (Microsoft, 2015) [downloadable]
+ dotnet462                MS .NET 4.6.2 (Microsoft, 2016) [downloadable]
+ dotnet46                 MS .NET 4.6 (Microsoft, 2015) [downloadable]
++dotnet471                MS .NET 4.7.1 (Microsoft, 2017) [downloadable]
+ dotnet472                MS .NET 4.7.2 (Microsoft, 2018) [downloadable]
+ dotnet_verifier          MS .NET Verifier (Microsoft, 2016) [downloadable]
+ dpvoice                  Microsoft dpvoice dpvvox dpvacm Audio dlls (Microsoft, 2002) [downloadable]
+diff --git a/files/verbs/dlls.txt b/files/verbs/dlls.txt
+index 66464a6..fcccf0e 100644
+--- a/files/verbs/dlls.txt
++++ b/files/verbs/dlls.txt
+@@ -74,6 +74,7 @@ dotnet452                MS .NET 4.5.2 (Microsoft, 2012) [downloadable]
+ dotnet461                MS .NET 4.6.1 (Microsoft, 2015) [downloadable]
+ dotnet462                MS .NET 4.6.2 (Microsoft, 2016) [downloadable]
+ dotnet46                 MS .NET 4.6 (Microsoft, 2015) [downloadable]
++dotnet471                MS .NET 4.7.1 (Microsoft, 2017) [downloadable]
+ dotnet472                MS .NET 4.7.2 (Microsoft, 2018) [downloadable]
+ dotnet_verifier          MS .NET Verifier (Microsoft, 2016) [downloadable]
+ dpvoice                  Microsoft dpvoice dpvvox dpvacm Audio dlls (Microsoft, 2002) [downloadable]
+diff --git a/files/verbs/download.txt b/files/verbs/download.txt
+index eda684d..97a76ba 100644
+--- a/files/verbs/download.txt
++++ b/files/verbs/download.txt
+@@ -109,6 +109,7 @@ dotnet452
+ dotnet46
+ dotnet461
+ dotnet462
++dotnet471
+ dotnet472
+ dotnet_verifier
+ dpvoice
+diff --git a/src/winetricks b/src/winetricks
+index 582f37a..79f19c0 100755
+--- a/src/winetricks
++++ b/src/winetricks
+@@ -884,6 +884,7 @@ w_dotnet_verify()
+         dotnet46) version="4.6" ;;
+         dotnet461) version="4.6.1" ;;
+         dotnet462) version="4.6.2" ;;
++        dotnet471) version="4.7.1" ;;
+         dotnet472) version="4.7.2" ;;
+         *) echo error ; exit 1 ;;
+     esac
+@@ -7586,14 +7587,14 @@ load_dotnet40()
+ 
+     w_try_cd "$W_CACHE/$W_PACKAGE"
+ 
+-    WINEDLLOVERRIDES=fusion=b "$WINE" dotNetFx40_Full_x86_x64.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"} || true
++    WINEDLLOVERRIDES=fusion=b "$WINE" dotNetFx40_Full_x86_x64.exe ${W_OPT_UNATTENDED:+/q /c:"install.exe /q"} && wineserver -k
+ 
+     w_override_dlls native mscoree
+ 
+-    "$WINE" reg add "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full" /v Install /t REG_DWORD /d 0001 /f
+-    "$WINE" reg add "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full" /v Version /t REG_SZ /d "4.0.30319" /f
++    #"$WINE" reg add "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full" /v Install /t REG_DWORD /d 0001 /f
++    #"$WINE" reg add "HKLM\\Software\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full" /v Version /t REG_SZ /d "4.0.30319" /f
+ 
+-    W_NGEN_CMD="$WINE $WINEPREFIX/drive_c/windows/Microsoft.NET/Framework/v4.0.30319/ngen.exe executequeueditems"
++    #W_NGEN_CMD="$WINE $WINEPREFIX/drive_c/windows/Microsoft.NET/Framework/v4.0.30319/ngen.exe executequeueditems"
+ 
+     w_unset_winver
+ }
+@@ -7860,6 +7861,52 @@ verify_dotnet462()
+ 
+ #----------------------------------------------------------------
+ 
++w_metadata dotnet471 dlls \
++    title="MS .NET 4.7.1" \
++    publisher="Microsoft" \
++    year="2017" \
++    media="download" \
++    conflicts="dotnet20 dotnet20sdk dotnet20sp1 dotnet20sp2 dotnet35sp1 dotnet46 dotnet461 dotnet462 vjrun20" \
++    installed_file1="c:/windows/dotnet471.installed.workaround"
++
++load_dotnet471()
++{
++    # Official version. See https://www.microsoft.com/en-US/download/details.aspx?id=56116
++    w_download http://download.microsoft.com/download/9/E/6/9E63300C-0941-4B45-A0EC-0008F96DD480/NDP471-KB4033342-x86-x64-AllOS-ENU.exe 63dc850df091f3f137b5d4392f47917f847f8926dc8af1da9bfba6422e495805
++    file_package="NDP471-KB4033342-x86-x64-AllOS-ENU.exe"
++    unattended_args="/q"
++
++    # note : we can't conflict with dotnet40 as the workaround requires to kill wineserver
++    w_call dotnet40
++
++    # double native mscoree enforcing
++    w_override_dlls native mscoree
++
++    w_set_winver win7
++
++    w_try_cd "$W_CACHE/$W_PACKAGE"
++
++    WINEDLLOVERRIDES=fusion=b "$WINE" "$file_package" ${W_OPT_UNATTENDED:+$unattended_args} && wineserver -k
++    status=$?
++
++    echo "exit status: $status"
++
++    case $status in
++        0) ;;
++        5) w_die "exit status $status - user selected 'Cancel'" ;;
++        *) w_die "exit status $status - $W_PACKAGE installation failed" ;;
++    esac
++
++    # The only unique files are temporary ones. As a workaround, touch a file instead so that we know it's been installed for list-installed
++    w_try touch "${W_WINDIR_UNIX}/dotnet471.installed.workaround"
++}
++
++verify_dotnet471()
++{
++    w_dotnet_verify dotnet471
++}
++#----------------------------------------------------------------
++
+ w_metadata dotnet_verifier dlls \
+     title="MS .NET Verifier" \
+     publisher="Microsoft" \


### PR DESCRIPTION
Without it, MTGA Arena doesn't install (and it's a VERY popular game).