### PR TITLE
update innoextract and add 7za

### DIFF
--- a/tools/innoextract/build.sh
+++ b/tools/innoextract/build.sh
@@ -5,7 +5,7 @@ set -e
 source ../../lib/util.sh
 
 pkg_name="innoextract"
-version="1.7-pre"
+version="1.8-pre"
 arch=$(uname -m)
 root_dir=$(pwd)
 source_dir="${root_dir}/${pkg_name}-src"

--- a/tools/p7zip/build.sh
+++ b/tools/p7zip/build.sh
@@ -25,6 +25,7 @@ BuildProject() {
     cd $source_dir
     make clean
     make 7z
+    make 7za
     rm -rf $bin_dir
     mv ./bin $bin_dir
 }


### PR DESCRIPTION
This updates the version of innoextract and adds `7za` to the runtime when building p7zip.

See https://github.com/lutris/lutris/pull/2241 