### PR TITLE
Use tar.xz instead of tar.gz for Wine runner

### DIFF
--- a/runners/wine/build.sh
+++ b/runners/wine/build.sh
@@ -318,8 +318,8 @@ Package() {
 
     rm -rf ${bin_dir}/include
 
-    dest_file="wine-${filename_opts}${version}-${arch}.tar.gz"
-    tar czf ${dest_file} ${bin_dir}
+    dest_file="wine-${filename_opts}${version}-${arch}.tar.xz"
+    tar cJf ${dest_file} ${bin_dir}
 }
 
 UploadRunner() {


### PR DESCRIPTION
This halves the size of produced wine build and requires no change in the client whatsoever.