### PR TITLE
Fix installation of dependencies when building Mednafen runner

### DIFF
--- a/runners/mednafen/build.sh
+++ b/runners/mednafen/build.sh
@@ -18,7 +18,7 @@ src_archive="${runner_name}-${version}.tar.xz"
 src_url="https://mednafen.github.io/releases/files/${src_archive}"
 
 deps="libsndfile-dev"
-install_deps $deps
+sudo apt install -y $deps
 
 wget "${src_url}"
 tar xJf "${src_archive}"


### PR DESCRIPTION
Again, we should do this for every runner script, but I don't have time right now unfortunately.