### PR TITLE
Various small fixes & improvements

### DIFF
--- a/runners/wine/build.sh
+++ b/runners/wine/build.sh
@@ -315,8 +315,11 @@ Package() {
         find ${bin_dir}/lib64 -name "*.so" -exec strip {} \;
     fi
     #copy sdl2, faudio, and ffmpeg libraries
-    cp -R $runtime_path/lib64/* ${bin_dir}/lib64/
     cp -R $runtime_path/lib32/* ${bin_dir}/lib/
+
+    if [ "$(uname -m)" = "x86_64" ]; then
+        cp -R $runtime_path/lib64/* ${bin_dir}/lib64/
+    fi
 
     rm -rf ${bin_dir}/include
 

--- a/runners/wine/build.sh
+++ b/runners/wine/build.sh
@@ -56,7 +56,7 @@ bin_dir="${filename_opts}${version}-${arch}"
 wine32_archive="${bin_dir}-32bit.tar.gz"
 
 InstallDependencies() {
-    sudo apt install -y autoconf bison debhelper desktop-file-utils docbook-to-man \
+    sudo apt install -y autoconf bison ccache debhelper desktop-file-utils docbook-to-man \
         docbook-utils docbook-xsl flex fontforge gawk gettext libacl1-dev \
         libasound2-dev libcapi20-dev libcloog-ppl1 libcups2-dev libdbus-1-dev \
         libgif-dev libglu1-mesa-dev libgphoto2-dev libgsm1-dev libgtk-3-dev \


### PR DESCRIPTION
What this does:
1) adds ccache as a dependency and makes use of it (saving a tremendous amount of build time)
2) adds an option to only keep the final build and discard everything else that gets created during building
3) now fetches sources when possible instead of always cloning them (again, saving a lot of time)
4) adds a check whether build is actually 64-bit when copying 64-bit faudio libraries.