### PR TITLE
libretro: Update RetroArch and build scripts

### DIFF
--- a/runners/libretro/build.sh
+++ b/runners/libretro/build.sh
@@ -58,22 +58,26 @@ BuildRetroarch() {
     # TODO: Restore files that pushed the package size to be too big
     # - assets/wallpapers
     # - assets/xmb/retroactive
-    DESTDIR=${bin_dir}/assets make -C media/assets install
+    make -C media/assets install DESTDIR="${bin_dir}" INSTALLDIR=/assets
     rm -rf ${bin_dir}/assets/.git \
         ${bin_dir}/assets/src \
         ${bin_dir}/assets/switch \
         ${bin_dir}/assets/nxrgui \
         ${bin_dir}/assets/wallpapers \
-        ${bin_dir}/assets/xmb/retroactive
+        ${bin_dir}/assets/xmb/automatic \
+        ${bin_dir}/assets/xmb/dot-art \
+        ${bin_dir}/assets/xmb/neoactive \
+        ${bin_dir}/assets/xmb/retrosystem \
+        ${bin_dir}/assets/xmb/systematic
 
     # autoconfig
-    DESTDIR=${bin_dir}/autoconfig make -C media/autoconfig install
+    make -C media/autoconfig install DESTDIR="${bin_dir}" INSTALLDIR=/autoconfig
 
     # Info files
     cp -a ../dist/info ${bin_dir}
 
     # Database
-    DESTDIR=${bin_dir}/database make -C media/libretrodb install
+    make -C media/libretrodb install DESTDIR="${bin_dir}" INSTALLDIR=/database
 }
 
 BuildLibretroCore() {

--- a/runners/libretro/build.sh
+++ b/runners/libretro/build.sh
@@ -8,7 +8,7 @@ source ${lib_path}util.sh
 source ${lib_path}upload_handler.sh
 
 runner_name=$(get_runner)
-retroarch_version="1.8.5
+retroarch_version="1.8.5"
 root_dir="$(pwd)"
 source_dir="${root_dir}/libretro-super"
 bin_dir="${root_dir}/retroarch"

--- a/runners/libretro/build.sh
+++ b/runners/libretro/build.sh
@@ -58,7 +58,7 @@ BuildRetroarch() {
     # TODO: Restore files that pushed the package size to be too big
     # - assets/wallpapers
     # - assets/xmb/retroactive
-    cp -a media/assets ${bin_dir}
+    DESTDIR=${bin_dir}/assets make -C media/assets install
     rm -rf ${bin_dir}/assets/.git \
         ${bin_dir}/assets/src \
         ${bin_dir}/assets/switch \
@@ -67,14 +67,13 @@ BuildRetroarch() {
         ${bin_dir}/assets/xmb/retroactive
 
     # autoconfig
-    cp -a media/autoconfig ${bin_dir}
+    DESTDIR=${bin_dir}/autoconfig make -C media/autoconfig install
 
     # Info files
     cp -a ../dist/info ${bin_dir}
 
     # Database
-    mkdir -p ${bin_dir}/database
-    cp -a -t ${bin_dir}/database media/libretrodb/cht media/libretrodb/cursors media/libretrodb/rdb
+    DESTDIR=${bin_dir}/database make -C media/libretrodb install
 }
 
 BuildLibretroCore() {


### PR DESCRIPTION
This switches to using `make` for the asset build scripts.

References #117