### PR TITLE
ppas: add missing vkd3d ppa

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -10,9 +10,9 @@ InstallDependencies() {
     # this package is necessary to add repositories using add-apt-repository
     sudo lxc exec $container -- apt -y install software-properties-common
     sudo lxc exec $container -- add-apt-repository ppa:cybermax-dexter/sdl2-backport -y
+    sudo lxc exec $container -- add-apt-repository ppa:cybermax-dexter/vkd3d -y
     sudo lxc exec $container -- apt update
     sudo lxc exec $container -- apt -y install wget curl build-essential git python openssh-server s3cmd awscli vim zsh fontconfig
-
 }
 
 SetupSSH() {


### PR DESCRIPTION
After a clean setup I found the following errors due to this ppa being missing:

E: Unable to locate package libvkd3d1
E: Unable to locate package libvkd3d-dev
E: Unable to locate package libvkd3d-utils1
E: Unable to locate package libvkd3d-shader1
E: Unable to locate package vkd3d-demos